### PR TITLE
feat: Integrate Koin for dependency injection

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -15,7 +14,7 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_11)
         }
     }
-    
+
     listOf(
         iosArm64(),
         iosSimulatorArm64()
@@ -25,22 +24,23 @@ kotlin {
             isStatic = true
         }
     }
-    
+
     js {
         browser()
         binaries.executable()
     }
-    
+
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()
         binaries.executable()
     }
-    
+
     sourceSets {
         androidMain.dependencies {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
+            implementation(libs.koin.android)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -51,9 +51,15 @@ kotlin {
             implementation(compose.components.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
+            
+            // Koin
+            implementation(libs.koin.core)
+            implementation(libs.koin.compose)
+            implementation(libs.koin.compose.viewmodel)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.koin.test)
         }
     }
 }

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".ZaicoApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/composeApp/src/androidMain/kotlin/jp/kyamlab/zaico/ZaicoApplication.kt
+++ b/composeApp/src/androidMain/kotlin/jp/kyamlab/zaico/ZaicoApplication.kt
@@ -1,0 +1,14 @@
+package jp.kyamlab.zaico
+
+import android.app.Application
+import jp.kyamlab.zaico.di.initKoin
+import org.koin.android.ext.koin.androidContext
+
+class ZaicoApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        initKoin {
+            androidContext(this@ZaicoApplication)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/App.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/App.kt
@@ -2,16 +2,18 @@ package jp.kyamlab.zaico
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.viewmodel.compose.viewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.annotation.KoinExperimentalAPI
 import presentation.stock.StockScreen
 import presentation.stock.StockViewModel
 
+@OptIn(KoinExperimentalAPI::class)
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        val viewModel: StockViewModel = viewModel { StockViewModel() }
+        val viewModel: StockViewModel = koinViewModel()
         StockScreen(viewModel = viewModel)
     }
 }

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/di/AppModule.kt
@@ -1,0 +1,9 @@
+package jp.kyamlab.zaico.di
+
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+import presentation.stock.StockViewModel
+
+val appModule = module {
+    viewModelOf(::StockViewModel)
+}

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/di/Koin.kt
@@ -8,5 +8,3 @@ fun initKoin(appDeclaration: KoinAppDeclaration = {}) =
         appDeclaration()
         modules(platformModule, appModule)
     }
-
-fun initKoin() = initKoin {}

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/di/Koin.kt
@@ -1,0 +1,12 @@
+package jp.kyamlab.zaico.di
+
+import org.koin.core.context.startKoin
+import org.koin.dsl.KoinAppDeclaration
+
+fun initKoin(appDeclaration: KoinAppDeclaration = {}) =
+    startKoin {
+        appDeclaration()
+        modules(platformModule, appModule)
+    }
+
+fun initKoin() = initKoin {}

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/di/PlatformModule.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/di/PlatformModule.kt
@@ -1,0 +1,8 @@
+package jp.kyamlab.zaico.di
+
+import jp.kyamlab.zaico.getPlatform
+import org.koin.dsl.module
+
+val platformModule = module {
+    single { getPlatform() }
+}

--- a/composeApp/src/iosMain/kotlin/jp/kyamlab/zaico/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/jp/kyamlab/zaico/MainViewController.kt
@@ -1,5 +1,13 @@
 package jp.kyamlab.zaico
 
 import androidx.compose.ui.window.ComposeUIViewController
+import jp.kyamlab.zaico.di.initKoin
 
-fun MainViewController() = ComposeUIViewController { App() }
+@Suppress("FunctionName", "unused")
+fun MainViewController() = ComposeUIViewController(
+    configure = {
+        initKoin()
+    }
+) {
+    App()
+}

--- a/composeApp/src/webMain/kotlin/jp/kyamlab/zaico/main.kt
+++ b/composeApp/src/webMain/kotlin/jp/kyamlab/zaico/main.kt
@@ -2,9 +2,11 @@ package jp.kyamlab.zaico
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
+import jp.kyamlab.zaico.di.initKoin
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
+    initKoin()
     ComposeViewport {
         App()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ androidx-testExt = "1.3.0"
 composeMultiplatform = "1.9.3"
 junit = "4.13.2"
 kotlin = "2.2.21"
+koin = "4.1.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -24,6 +25,11 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
+koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit sets up Koin as the dependency injection framework for the Kotlin Multiplatform project.

- Add Koin dependencies for core, Android, Compose, and testing in `libs.versions.toml` and `build.gradle.kts`.
- Implement `appModule`, `platformModule`, and a shared `initKoin` initialization function in the `commonMain` source set.
- Configure platform-specific entry points to initialize Koin:
    - **Android**: Create `ZaicoApplication` and register it in `AndroidManifest.xml`.
    - **iOS**: Update `MainViewController` to call `initKoin`.
    - **Web**: Update `main.kt` to call `initKoin`.
- Refactor the `App` composable to use `koinViewModel()` for retrieving the `StockViewModel`.