### PR TITLE
refactor: パッケージ構造の整理とベースパッケージの適用

### DIFF
--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/App.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/App.kt
@@ -2,11 +2,11 @@ package jp.kyamlab.zaico
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import jp.kyamlab.zaico.presentation.stock.StockScreen
+import jp.kyamlab.zaico.presentation.stock.StockViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
-import presentation.stock.StockScreen
-import presentation.stock.StockViewModel
 
 @OptIn(KoinExperimentalAPI::class)
 @Composable

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/di/AppModule.kt
@@ -1,8 +1,8 @@
 package jp.kyamlab.zaico.di
 
+import jp.kyamlab.zaico.presentation.stock.StockViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
-import presentation.stock.StockViewModel
 
 val appModule = module {
     viewModelOf(::StockViewModel)

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/domain/model/StockItem.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/domain/model/StockItem.kt
@@ -1,3 +1,3 @@
-package domain.model
+package jp.kyamlab.zaico.domain.model
 
 data class StockItem(val id: Long, val name: String, val quantity: Int)

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/presentation/stock/StockListItem.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/presentation/stock/StockListItem.kt
@@ -1,4 +1,4 @@
-package presentation.stock
+package jp.kyamlab.zaico.presentation.stock
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,7 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import domain.model.StockItem
+import jp.kyamlab.zaico.domain.model.StockItem
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import zaico.composeapp.generated.resources.Res

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/presentation/stock/StockScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/presentation/stock/StockScreen.kt
@@ -1,4 +1,4 @@
-package presentation.stock
+package jp.kyamlab.zaico.presentation.stock
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/presentation/stock/StockUiState.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/presentation/stock/StockUiState.kt
@@ -1,0 +1,7 @@
+package jp.kyamlab.zaico.presentation.stock
+
+import jp.kyamlab.zaico.domain.model.StockItem
+
+data class StockUiState(
+    val stockItems: List<StockItem> = emptyList()
+)

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/presentation/stock/StockViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/zaico/presentation/stock/StockViewModel.kt
@@ -1,7 +1,7 @@
-package presentation.stock
+package jp.kyamlab.zaico.presentation.stock
 
 import androidx.lifecycle.ViewModel
-import domain.model.StockItem
+import jp.kyamlab.zaico.domain.model.StockItem
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/composeApp/src/commonMain/kotlin/presentation/stock/StockUiState.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/stock/StockUiState.kt
@@ -1,7 +1,0 @@
-package presentation.stock
-
-import domain.model.StockItem
-
-data class StockUiState(
-    val stockItems: List<StockItem> = emptyList()
-)


### PR DESCRIPTION
プロジェクト全体のパッケージ構造を見直し、すべてのソースファイルを `jp.kyamlab.zaico` 配下に移動しました。

- `domain` および `presentation` パッケージを `jp.kyamlab.zaico` 配下に配置するようにディレクトリ構造を変更
- 各ファイルの `package` 宣言および `import` 文を新しいパッケージ構造に合わせて更新
- `StockUiState.kt` を新しいパッケージパスに再作成
- パッケージ移動に伴い、`App.kt` および `AppModule.kt` 内のインポート参照を修正